### PR TITLE
feat(data): add file= kwarg to table and yaml to load from disk

### DIFF
--- a/src/cmx/backends/components.py
+++ b/src/cmx/backends/components.py
@@ -11,10 +11,39 @@ down explicitly. Anything that needs heavy third-party libraries (numpy, PIL,
 pyyaml) imports them lazily so ``import cmx`` stays cheap.
 """
 
+import os
 from io import StringIO
 
 from .. import utils
 from ..utils import is_subclass, to_snake  # re-exported for backwards compatibility
+
+
+def read_table(file, sep=None, **kwargs):
+    """Load a tabular file into a pandas ``DataFrame``, inferred by extension.
+
+    Supports ``.csv`` / ``.tsv`` (text), ``.json``, ``.parquet``, and Excel
+    (``.xls`` / ``.xlsx``); ``.yaml`` / ``.yml`` are parsed and fed to the
+    ``DataFrame`` constructor. Extra ``kwargs`` are forwarded to the matching
+    pandas reader. ``sep`` overrides the delimiter for text files (defaulting to
+    a tab for ``.tsv`` and a comma otherwise). Unknown extensions are read as CSV.
+    """
+    import pandas as pd
+
+    ext = os.path.splitext(file)[1].lower()
+    if ext == ".json":
+        return pd.read_json(file, **kwargs)
+    if ext == ".parquet":
+        return pd.read_parquet(file, **kwargs)
+    if ext in (".xls", ".xlsx"):
+        return pd.read_excel(file, **kwargs)
+    if ext in (".yaml", ".yml"):
+        import yaml
+
+        with open(file) as f:
+            return pd.DataFrame(yaml.safe_load(f))
+    if sep is None:
+        sep = "\t" if ext == ".tsv" else ","
+    return pd.read_csv(file, sep=sep, **kwargs)
 
 
 def attrs(class_name=None, **kwargs):
@@ -381,12 +410,17 @@ class Table(Component):
 
     data = None
 
-    def __init__(self, table=None, show_index=None, format="github", sep=",*", logger=None, **kwargs):
+    def __init__(self, table=None, file=None, show_index=None, format="github", sep=",*", logger=None, **kwargs):
         super().__init__(logger=logger)
         self.show_index = show_index
         self.kwargs = kwargs  # forwarded to pandas' to_markdown / to_html
         self.format = format
-        if table is None:
+        if file is not None:
+            # Load tabular data straight from disk (csv/tsv/json/parquet/excel/yaml).
+            # ``,*`` is the constructor's regex default for inline strings; let
+            # read_table infer the delimiter unless the caller set a real one.
+            self.data = read_table(file, sep=None if sep == ",*" else sep)
+        elif table is None:
             pass
         else:
             import pandas as pd

--- a/src/cmx/backends/markdown.py
+++ b/src/cmx/backends/markdown.py
@@ -141,9 +141,18 @@ class CommonMark(components.Article):
         self.children.append(p)
         return p
 
-    def yaml(self, data, **kwargs):
+    def yaml(self, data=None, file=None, **kwargs):
+        """Render YAML as a code block.
+
+        Pass ``data`` to dump a Python object, or ``file=`` to read a ``.yaml``
+        file straight from disk (its contents are shown verbatim, comments and
+        all).
+        """
         import yaml
 
+        if file is not None:
+            with open(file) as f:
+                return self.pre(f.read().rstrip(), lang="yaml")
         return self.pre(yaml.dump(data).rstrip(), lang="yaml")
 
     def csv(self, csv, show_index=False, **kwargs):

--- a/tests/test_from_file.py
+++ b/tests/test_from_file.py
@@ -1,0 +1,38 @@
+"""``file=`` kwargs: load table/yaml content straight from disk."""
+
+from cmx.backends.components import Article
+from cmx.backends.markdown import CommonMark
+
+
+def test_table_from_csv(tmp_path):
+    p = tmp_path / "t.csv"
+    p.write_text("a,b\n1,2\n3,4\n")
+    doc = Article()
+    assert doc.table(file=str(p))._md == (
+        "|   a |   b |\n"
+        "|-----|-----|\n"
+        "|   1 |   2 |\n"
+        "|   3 |   4 |\n"
+    )
+
+
+def test_table_from_tsv(tmp_path):
+    p = tmp_path / "t.tsv"
+    p.write_text("a\tb\n1\t2\n")
+    doc = Article()
+    assert doc.table(file=str(p)).data.columns.tolist() == ["a", "b"]
+
+
+def test_table_from_yaml(tmp_path):
+    p = tmp_path / "rows.yaml"
+    p.write_text("- {a: 1, b: 2}\n- {a: 3, b: 4}\n")
+    doc = Article()
+    assert doc.table(file=str(p)).data.shape == (2, 2)
+
+
+def test_yaml_from_file_is_verbatim(tmp_path):
+    p = tmp_path / "cfg.yaml"
+    p.write_text("# my config\nlr: 0.1\nepochs: 10\n")
+    doc = CommonMark(filename=str(tmp_path / "out.md"))
+    # Comments are preserved -- the file content is shown as-is.
+    assert doc.yaml(file=str(p))._md == "```yaml\n# my config\nlr: 0.1\nepochs: 10\n```\n"


### PR DESCRIPTION
## Summary
Adds a `file=` kwarg to the two live document methods so content can be loaded straight from disk.

- **`doc.table(file=...)`** — tabular path. New `read_table()` helper infers the reader by extension: `.csv`/`.tsv` → `read_csv`, `.json` → `read_json`, `.parquet` → `read_parquet`, `.xls`/`.xlsx` → `read_excel`, `.yaml`/`.yml` (list of records) → `DataFrame`. Sidesteps the constructor's `,*` regex default so real CSVs parse correctly (comma for `.csv`, tab for `.tsv`, overridable via `sep=`).
- **`doc.yaml(file=...)`** — config path. Renders the file **verbatim** in a ` ```yaml ` block, preserving comments. The existing `data`-dump behavior is unchanged.

The two methods split intent cleanly: tabular YAML → `table`, config/structured YAML → `yaml`.

## Test plan
- New `tests/test_from_file.py` covers CSV, TSV, list-of-records YAML, and verbatim YAML-file cases.
- Full suite: 18 passed, 3 skipped.