### PR TITLE
skill: update CMX plugin skills to the 0.0.49 API

### DIFF
--- a/.claude-plugin/cmx-basics.md
+++ b/.claude-plugin/cmx-basics.md
@@ -4,22 +4,45 @@ This skill helps you understand and use CMX for creating live, interactive docum
 
 ## What is CMX?
 
-CMX is a Python library that enables REPL-style documentation generation. It works like a Jupyter notebook but integrates directly into your Python scripts using context managers.
+CMX is a Python library that generates Markdown documentation directly from your Python scripts. It works like a Jupyter notebook, but lives inside plain `.py` files: you wrap code in `with doc:` to capture its source and output, add prose and rich blocks with the document API, and CMX writes it all to a `.md` file next to your script.
+
+The default (and primary) backend is **Markdown**, with partial HTML rendering for some components (rows, videos). HTML and LaTeX backends are stubs — Markdown is the backend you use.
+
+## Installation
+
+```bash
+pip install cmx
+```
+
+The core is dependency-free: `import cmx` pulls in zero third-party packages. Requires **Python 3.11+**. Richer blocks load their dependencies lazily — install only the extras you use:
+
+| Install | Pulls | Enables |
+|---|---|---|
+| `pip install cmx` | nothing | core: text, `@`/`|`/call operators, `doc.print`, `doc.pre`, capture, flush |
+| `pip install 'cmx[tables]'` | pandas | `doc.table`, `doc.csv` (default `github` format) |
+| `pip install 'cmx[images]'` | pillow, numpy | array images: `doc.image` / `doc.figure` / `doc.video` |
+| `pip install 'cmx[figures]'` | matplotlib | `doc.savefig` |
+| `pip install 'cmx[yaml]'` | pyyaml | `doc.yaml` |
+| `pip install 'cmx[all]'` | all of the above | everything |
+
+Note: `tabulate` is **not** a runtime dependency. The default `github` table format renders through CMX's built-in pure-Python renderer (`cmx.backends.md_table`) and needs only pandas. `tabulate` is required only for alternate `format=` values (`pipe`, `grid`, ...).
 
 ## Basic Usage Pattern
 
 ```python
 from cmx import doc
 
-# Configure output (optional - auto-detects based on script name)
-doc.config(filename="output.md")
+# Anchor output to this script: writes <script>.md next to the script.
+doc.config(__file__)
 
-# Use 'with doc:' to capture code and output
+# Use 'with doc:' to capture the block's source AND run it.
 with doc:
     doc.print("Hello, World!")
 
     for i in range(5):
-        doc.print(i, end=' ')
+        doc.print(i, end=" ")
+
+doc.flush()
 ```
 
 ## Key Concepts
@@ -27,39 +50,117 @@ with doc:
 ### 1. The Global `doc` Object
 
 Import and use the global document object:
+
 ```python
 from cmx import doc
 ```
 
-### 2. Context Management
+### 2. Configuration — `doc.config(__file__)`
 
-Code inside `with doc:` blocks is captured and shown in output:
+The recommended call is `doc.config(__file__)`. It anchors output to the script you run:
+
+- The `.md` lands **next to the script** (`report.py` → `report.md`).
+- The **working directory** (`wd`) defaults to the script's folder, so the script produces the same output no matter where you launch Python from.
+
+CMX decides what the argument means by its extension: a `.py` path is the **script**; anything else (or the `filename=` keyword) is treated as the explicit **output Markdown path**.
+
 ```python
-with doc:
-    # This code appears in the markdown output
-    result = 42
-    doc.print(f"The answer is {result}")
+doc.config(__file__)                  # script-relative: report.py -> report.md
+doc.config("report.md")               # explicit output path (wd = its directory)
+doc.config(filename="report.md")      # equivalent keyword form
+doc.config(__file__, wd="/tmp/out")   # relocate everything under /tmp/out
 ```
 
-### 3. Output Methods
+On configure, CMX prints a green `File output at file://...` line you can click through to.
 
-- `doc.print(*args, sep=" ", end="\n")` - Print values (like built-in print)
-- `doc("text")` or `doc.md("text")` - Add markdown text
-- `doc.table(dataframe)` - Display tables
-- `doc.image(array, src="path.png")` - Save and display images
-- `doc.yaml(data)` - Display structured data as YAML
+`doc.config(...)` returns `self`, so calls chain.
 
-### 4. File Configuration
+### 3. The `figdir` template — where assets land
 
-Control where output is written:
+Assets (images, figures, videos) go into a **figure directory** (`figdir`). It is a template string; `{fname}` expands to the Markdown file's name **without** its extension. The default is `"{fname}"`, so each document gets its own per-file asset folder.
+
 ```python
-# Explicit filename
-doc.config(filename="results.md")
+doc.config(__file__)                   # 04_images.py -> assets in 04_images/
+doc.config(__file__, figdir="assets")  # all assets in assets/
+doc.config(__file__, figdir="")        # assets beside the .md, no subfolder
+```
 
-# Auto-detect from script name (example.py → example.md)
-# (This happens automatically if you don't call config)
+Read the resolved values back from `doc.filename` (the basename **with** extension, e.g. `report.md`) and `doc.figdir` (the name **without** extension, e.g. `report`).
 
-# Create multiple documents
+### 4. Asset path resolution
+
+When you call `doc.image` / `doc.figure` / `doc.video` / `doc.savefig`, CMX decides where `src` lives by one rule — **does the name contain a slash?**
+
+| You pass | CMX stores | Why |
+|---|---|---|
+| `"random.png"` (bare name) | `figdir/random.png` | bare names go under `figdir` |
+| `"sub/x.png"` (has a slash) | `sub/x.png` | explicit path wins, used as-is |
+
+Links are written **relative to the `.md`**, and stored paths use forward slashes, so the document and its assets move together. Saving **creates directories automatically** (the default `on_save` hook), so you never pre-create asset folders.
+
+### 5. Context Management
+
+CMX gives you three context managers for deciding what lands in the document:
+
+- `with doc:` — captures the block's source as a Python code fence **and runs it**. Source plus any `doc.print` output appear in document order.
+- `with doc.hide:` — **runs** the body but does **not** show its source. Variables defined inside persist afterward. Use it for imports, data loading, helpers, expensive setup.
+- `with doc.skip:` — does **not** run the body at all (nothing executes, nothing appears). Implemented via a frame-tracing trick, so it can interfere with debuggers such as PyCharm's pydev — avoid it while stepping through code under a debugger.
+
+```python
+with doc.hide:
+    import numpy as np
+    data = np.random.randn(1000)   # runs, hidden; `data` stays in scope
+
+with doc:
+    doc @ "### Summary"
+    doc.print(f"Mean: {data.mean():.4f}")   # shown: source + output
+
+with doc.skip:
+    expensive_training()           # never runs while skipped
+```
+
+### 6. Output Methods
+
+- `doc("text")`, `doc @ "text"`, `"text" | doc` — three equivalent forms to add a markdown text block (see Patterns below). `doc.md` is an alias for the call form.
+- `doc.print(*args, sep=" ", end="\n")` — print values like the built-in `print` (also echoes to stdout).
+- `doc.pre(text, lang=None)` — a raw code/preformatted block.
+- `doc.table(df)` / `doc.csv(csv_string)` — tables.
+- `doc.yaml(data)` — render a Python object as a YAML code block.
+- `doc.image(arr, src=...)`, `doc.figure(...)`, `doc.savefig(key)`, `doc.video(frames, src=...)` — rich blocks (see the components skill).
+- `doc.flush()` — render the accumulated blocks and append them to the `.md`.
+
+### 7. Adding text — three forms and `end=`
+
+```python
+doc("# Title", end="\n")   # call form (end="\n" is the default)
+doc @ "# Title"            # prefix @ operator
+"# Title" | doc            # postfix | operator
+```
+
+All three append a text block and return `doc`, so they chain. Only the call form takes keywords like `end=`. Use `end=""` to keep the next block on the same line:
+
+```python
+doc("Status: ", end="")
+doc("OK")                  # -> "Status: OK"
+```
+
+Text is dedented by default (`dedent=True`), so triple-quoted multi-line strings stay clean. The left-side pipe `doc | other` is not implemented and raises `NotImplementedError`; only `"text" | doc` works.
+
+### 8. `doc.print` coalescing
+
+Consecutive `doc.print` calls **merge into a single code block** — they don't each produce their own fence. A non-print block in between starts a fresh code block.
+
+```python
+with doc:
+    doc.print("line 1")
+    doc.print("line 2")     # joins the same code block as line 1
+    doc("## A heading")     # breaks the run
+    doc.print("line 3")     # starts a new code block
+```
+
+### 9. Multiple documents
+
+```python
 doc2 = doc.new(filename="second_doc.md")
 ```
 
@@ -70,10 +171,14 @@ doc2 = doc.new(filename="second_doc.md")
 ```python
 from cmx import doc
 
+doc.config(__file__)
+
 with doc:
     doc("# My Results")
     for i in range(10):
-        doc.print(i, end=' ')
+        doc.print(i, end=" ")
+
+doc.flush()
 ```
 
 ### Pattern 2: Data Tables
@@ -82,70 +187,98 @@ with doc:
 import pandas as pd
 from cmx import doc
 
-data = pd.DataFrame({
-    'name': ['Alice', 'Bob'],
-    'score': [95, 87]
-})
+doc.config(__file__)
 
-with doc:
-    doc("# Test Scores")
-    doc.table(data)
+data = pd.DataFrame({"name": ["Alice", "Bob"], "score": [95, 87]})
+
+doc("# Test Scores")
+doc.table(data)
+doc.flush()
 ```
 
 ### Pattern 3: Visualization
 
 ```python
-import numpy as np
 import matplotlib.pyplot as plt
 from cmx import doc
 
-# Create a plot
-plt.plot([1, 2, 3, 4])
-plt.ylabel('values')
+doc.config(__file__)
 
-with doc:
-    doc("# My Plot")
-    doc.savefig("figures/plot.png")
+plt.plot([1, 2, 3, 4])
+plt.ylabel("values")
+
+doc("# My Plot")
+doc.savefig("plot.png")   # bare name -> lands under figdir, dir auto-created
+doc.flush()
 ```
 
-### Pattern 4: Development with Skip
+### Pattern 4: Run-but-hide vs. skip during development
 
 ```python
 from cmx import doc
 
-# Skip expensive computations during development
+doc.config(__file__)
+
+# RUNS but its source is not shown; variables persist.
+with doc.hide:
+    result = expensive_setup()
+
+# Does NOT run at all — parked until you're ready.
 with doc.skip:
-    # This runs but doesn't appear in output
-    expensive_training()
+    even_more_expensive_training()
 
 with doc:
-    # This appears in output
-    doc.print("Training complete!")
+    doc.print("Setup complete!", result)
+
+doc.flush()
 ```
+
+## Storage & integration hooks
+
+CMX has **no logger and no storage framework**. Storage and remote integration happen through **lifecycle hooks** — methods on the document, each with a sensible local-disk default. Override them to send text and assets anywhere (S3/GCS, a dashboard, an API).
+
+| Hook | Fires | Returns |
+|---|---|---|
+| `on_mount` | once, when `doc.config()` resolves output — the destination handshake | a `dest` (base key / URL / id), or `None` for local |
+| `on_save` | per binary asset (image / video / figure) | the **link** written into `![]( )` |
+| `on_flush` | per `doc.flush()` — a rendered text chunk | — |
+| `on_close` | once, on `doc.close()` / `atexit` | — |
+| `on_error` | per failed `with doc:` block (does not suppress the exception) | — |
+| `on_block` | every block, with `kind ∈ {text, code, table, image, figure, video}` | — |
+| `on_hide` / `on_skip` | when a `doc.hide` / `doc.skip` block is entered | — |
+
+All hooks are **keyword-only** and accept `**kw`, so new fields never break an existing override. Set them two ways:
+
+```python
+# 1) Bind a function on the instance (no `self`) — quick, one-off:
+doc.on_save = lambda *, data, path, **kw: my_upload(path, data)   # returns the link
+
+# 2) Subclass CommonMark and override (methods have `self`) — reusable:
+from cmx.backends.markdown import CommonMark
+
+class S3Doc(CommonMark):
+    def on_save(self, *, data, path, kind, dest, doc, **kw):
+        s3_put(path, encode(data))
+        return f"https://bucket.s3.amazonaws.com/{path}"
+```
+
+To keep the default behavior, capture-and-wrap it (`_save = doc.on_save; doc.on_save = lambda **kw: upload(**kw) or _save(**kw)`) or call `super().on_save(...)`. See the Hooks guide for the full lifecycle trace.
 
 ## Tips
 
-1. **Auto-detection**: If you don't call `doc.config()`, CMX automatically creates `script_name.md` next to your script
-2. **Remote logging**: Integrate with ML-Logger for remote document storage
-3. **Multiple backends**: CMX supports Markdown (default), HTML, and LaTeX output
-4. **Layout**: Use `doc.row` context for horizontal layouts (HTML only)
+1. **Use `doc.config(__file__)`** so output is script-relative and reproducible. If you skip `config` entirely, CMX lazily derives `script_name.md` from the calling frame.
+2. **Pass bare asset names** and let `figdir` organize them; reach for a slashed path only when an asset must live somewhere specific.
+3. **Call `doc.flush()`** to write the accumulated blocks. `with doc:` flushes automatically on exit; `doc.close()` (and `atexit`) finalize once.
 
 ## When to Use CMX
 
 - Creating documentation that stays in sync with code
 - Logging experiment results with code provenance
 - Building interactive tutorials
-- Generating reports from data analysis scripts
+- Generating reports from data-analysis scripts
 - Replacing Jupyter notebooks with plain Python scripts
-
-## Installation
-
-```bash
-pip install cmx
-```
 
 ## Learn More
 
 - Full documentation: https://cmx-python.readthedocs.io
-- Examples: Check the `examples/` directory in the repository
 - API Reference: https://cmx-python.readthedocs.io/en/latest/api/

--- a/.claude-plugin/cmx-components.md
+++ b/.claude-plugin/cmx-components.md
@@ -1,232 +1,199 @@
 # CMX Components Skill
 
-This skill provides detailed guidance on using CMX's rich components for creating comprehensive documentation.
+This skill provides detailed guidance on CMX's rich components for building documentation. CMX renders to **Markdown** (the backend), with partial HTML rendering for some components (rows, videos).
 
 ## Component Overview
 
-CMX provides several component types for different content:
+- **Text**: prose via `@` / `|` / call forms
+- **Print**: `print`-style output, coalesced into code blocks
+- **Pre / YAML**: raw and YAML code blocks
+- **Table**: tabular data from DataFrames, CSV, or files
+- **Image**: array or file images, auto-saved through `on_save`
+- **Figure / Savefig**: images and matplotlib figures with titles/captions
+- **Video**: video and GIF embedding
+- **Row**: horizontal layout container
 
-- **Text & Print**: Text output
-- **Table**: Tabular data from DataFrames or CSV
-- **Image**: Image embedding with auto-save
-- **Video**: Video and GIF embedding
-- **Figure**: Images with captions and titles
-- **YAML**: Structured data display
-- **Layout**: Row containers for horizontal arrangement
+Each rich block requires an extra (see the basics skill): tables need `cmx[tables]` (pandas), images need `cmx[images]` (pillow+numpy), `savefig` needs `cmx[figures]` (matplotlib), yaml needs `cmx[yaml]`. The core is dependency-free.
 
 ## Text Components
 
-### Print Component
-
-Works like Python's built-in `print()`:
+### Markdown Text — three equivalent forms
 
 ```python
 from cmx import doc
 
-with doc:
-    doc.print("Single line")
-    doc.print("Multiple", "arguments", sep="-")
-    doc.print("No newline", end='')
-    doc.print(" continues here")
+doc.config(__file__)
+
+doc("# Heading 1", end="\n")   # call form (end="\n" is the default)
+doc @ "## Heading 2"           # prefix @ operator
+"**Bold** and *italic*" | doc  # postfix | operator
 ```
 
-Output:
-```
-Single line
-Multiple-arguments
-No newline continues here
-```
+All three append a text block and return `doc`. `doc.md` is an alias for the call form. Only the call form accepts keywords such as `end=`; use `end=""` to keep the next block on the same line. A tuple spreads into one block per item: `doc @ ("First.", "Second.")`. The left-side pipe `doc | other` raises `NotImplementedError`. Text is dedented by default (`dedent=True`).
 
-### Markdown Text
+### Print Component
 
-Add raw markdown using `doc()` or `doc.md()`:
+Works like Python's `print()`, and also echoes to stdout:
 
 ```python
 with doc:
-    doc("# Heading 1")
-    doc("## Heading 2")
-    doc("**Bold** and *italic* text")
-    doc("- List item 1")
-    doc("- List item 2")
+    doc.print("Single line")
+    doc.print("Multiple", "arguments", sep="-")
+    doc.print("No newline", end="")
+    doc.print(" continues here")
+```
+
+**Coalescing:** consecutive `doc.print` calls merge into a single code block. Any non-print block in between starts a fresh code block.
+
+## Pre and YAML
+
+`doc.pre(text, lang=None)` emits a raw fenced code block. `doc.yaml` renders a Python object as a YAML code block, or reads a `.yaml` file from disk verbatim (comments and all):
+
+```python
+config = {"model": {"name": "ResNet50", "layers": 50}}
+
+doc("# Configuration")
+doc.yaml(config)               # dump a Python object
+doc.yaml(file="conf.yaml")     # show a YAML file verbatim
+```
+
+```yaml
+model:
+  name: ResNet50
+  layers: 50
 ```
 
 ## Table Component
 
-Display DataFrames or CSV data as markdown tables:
+Render DataFrames or CSV data as Markdown tables (needs `cmx[tables]`). CMX inserts a blank line before each table automatically.
 
 ```python
 import pandas as pd
 from cmx import doc
 
-# From DataFrame
+doc.config(__file__)
+
 df = pd.DataFrame({
-    'Name': ['Alice', 'Bob', 'Charlie'],
-    'Age': [25, 30, 35],
-    'Score': [95, 87, 92]
+    "Name": ["Alice", "Bob", "Charlie"],
+    "Age": [25, 30, 35],
+    "Score": [95, 87, 92],
 })
 
-with doc:
-    doc("# Results Table")
-    doc.table(df, show_index=False)
+doc("# Results Table")
+doc.table(df, show_index=False)   # show_index defaults to False
 ```
 
-Output:
-```markdown
-| Name    | Age | Score |
-|---------|-----|-------|
-| Alice   | 25  | 95    |
-| Bob     | 30  | 87    |
-| Charlie | 35  | 92    |
+The default `format="github"` is rendered by CMX's built-in pure-Python renderer (`cmx.backends.md_table`) and needs only pandas. Other formats fall back to pandas' `to_markdown` and require `tabulate`:
+
+```python
+doc.table(df, format="grid")   # needs `pip install tabulate`
+doc.table(df, format="pipe")   # needs `pip install tabulate`
+```
+
+### CSV strings and files
+
+`doc.csv` renders a CSV string directly; `doc.table` accepts the same string. To load from disk, pass `file=` — the extension is inferred (csv / tsv / json / parquet / excel / yaml):
+
+```python
+doc.csv("Model,Accuracy\nResNet50,0.95\nVGG16,0.87")
+
+doc.table(file="data.csv")       # also .tsv / .json / .parquet / .xlsx / .yaml
+doc.table(file="metrics.parquet")
 ```
 
 ## Image Component
 
-Save and display images:
+Save numpy arrays or reference existing files (needs `cmx[images]`). Saving creates directories automatically.
 
 ```python
 import numpy as np
 from cmx import doc
 
-# Create or load image data
-image = np.random.rand(100, 100, 3)  # RGB image
+doc.config(__file__)
+
+# RGB array: (height, width, 3), uint8 0–255
+image = (np.random.rand(100, 100, 3) * 255).astype(np.uint8)
 
 with doc:
-    # Save and display
-    doc.image(image, src="figures/random.png")
-
-    # With normalization
-    doc.image(image, src="figures/normalized.png", normalize=True)
-
-    # Just display existing image
-    doc.image(src="figures/existing.png", width="50%")
+    doc.image(image, src="random.png")              # bare name -> figdir/random.png
+    doc.image(image, src="random.png", normalize=True)
+    doc.image(src="existing.png")                   # reference a file, no array
 ```
 
-### Image Attributes
+### Image arguments (verified against `components.py`)
 
-- `image`: NumPy array (optional if `src` points to existing file)
-- `src`: Path to save/load image
-- `normalize`: Normalize pixel values to [0, 255]
-- `width`, `height`: Size attributes (CSS values like "50%" or "300px")
+- `image` — numpy array (omit it to reference an existing file via `src`).
+- `src` — asset path. A **bare name** lands under `figdir`; a name **with a slash** is used as-is. With no `src`, an array is inlined as a base64 `data:` URI.
+- `normalize` — forwarded to the saver to normalize pixel values.
+
+Note: `width` / `height` / `style` / `class_name` are **not** parameters of `doc.image` — do not pass them. (`doc.savefig` and `doc.figure` do accept `width` / `height` / `zoom`; see below.)
 
 ## Figure Component
 
-Images with titles and captions:
+`doc.figure` attaches a `title` and/or `caption` to an image. Same array-or-`src` rules as `doc.image`:
 
 ```python
-from cmx import doc
-import matplotlib.pyplot as plt
-
-# Create a plot
-plt.figure(figsize=(8, 6))
-plt.plot([1, 2, 3, 4], [1, 4, 9, 16])
-plt.xlabel('X axis')
-plt.ylabel('Y axis')
-
 with doc:
     doc.figure(
-        src="figures/plot.png",
-        title="Quadratic Function",
-        caption="Plot showing y = x²",
-        width="80%"
+        gradient,                 # array, or omit and pass src=
+        src="gradient.png",
+        title="Gradient",
+        caption="A horizontal color ramp.",
     )
 ```
 
-### Using Savefig
+### Savefig — save the current matplotlib figure
 
-Directly save the current matplotlib figure:
+`doc.savefig(key)` saves the **current** matplotlib figure and links it (needs `cmx[figures]`). The `key` resolves through `figdir` just like image `src`.
 
 ```python
 import matplotlib.pyplot as plt
 from cmx import doc
 
-plt.plot([1, 2, 3], [1, 2, 3])
+doc.config(__file__)
+
+plt.plot([1, 2, 3], [1, 4, 9])
 
 with doc:
-    doc.savefig("figures/simple.png", caption="A simple line plot")
+    doc.savefig("plot.png", caption="A simple line plot")
 ```
+
+`doc.savefig` accepts `caption`, `width`, `height`, `zoom`; any other keyword (`dpi`, `bbox_inches`, `transparent`, `facecolor`, `format`, ...) is forwarded straight to matplotlib's `savefig` and is **not** leaked into the `<img>` tag.
 
 ## Video Component
 
-Embed videos and GIFs:
+Embed videos and GIFs (frame arrays need `cmx[images]`):
 
 ```python
 import numpy as np
 from cmx import doc
 
-# Create video frames (T, H, W, C)
 frames = np.random.randint(0, 255, (30, 100, 100, 3), dtype=np.uint8)
 
 with doc:
-    # Save and display as GIF
-    doc.video(frames, src="videos/animation.gif")
-
-    # Display existing video
-    doc.video(src="videos/demo.mp4", width="640", height="480")
+    doc.video(frames, src="animation.gif")   # .gif renders as an Image
+    doc.video(src="demo.mp4")                # .mp4 renders as HTML5 <video>
 ```
 
-### Video Formats
+`.gif` sources render as an `Image` (works everywhere); other extensions render as an HTML5 `<video>` (shown only where HTML is rendered). The `src` resolves through `figdir` like other assets.
 
-- `.gif`: Displays as an image (works everywhere)
-- `.mp4`, `.webm`: Displays as HTML5 video (HTML backend only)
+## Layout — `doc.row()`
 
-## YAML Component
-
-Display structured data in YAML format:
-
-```python
-from cmx import doc
-
-config = {
-    'model': {
-        'name': 'ResNet50',
-        'layers': 50,
-        'pretrained': True
-    },
-    'training': {
-        'batch_size': 32,
-        'learning_rate': 0.001,
-        'epochs': 100
-    }
-}
-
-with doc:
-    doc("# Configuration")
-    doc.yaml(config)
-```
-
-Output:
-```yaml
-model:
-  name: ResNet50
-  layers: 50
-  pretrained: true
-training:
-  batch_size: 32
-  learning_rate: 0.001
-  epochs: 100
-```
-
-## Layout Components
-
-### Row Layout
-
-Arrange components horizontally (HTML backend):
+`doc.row()` is a **method call** (`with doc.row():`, not `with doc.row:`). It arranges its children in a horizontal flex container (an HTML `<div>`, so layout shows where HTML is rendered; the images themselves still render in plain Markdown).
 
 ```python
 import numpy as np
 from cmx import doc
 
-img1 = np.random.rand(100, 100, 3)
-img2 = np.random.rand(100, 100, 3)
+doc.config(__file__)
 
 with doc:
     doc("# Side-by-side Images")
-    with doc.row:
-        doc.image(img1, src="img1.png")
-        doc.image(img2, src="img2.png")
+    with doc.row():
+        for i in range(3):
+            img = (np.random.rand(50, 50, 3) * 255).astype(np.uint8)
+            doc.image(img, src=f"mini_{i}.png")
 ```
-
-Note: Row layouts use HTML and work best in rendered markdown or HTML output.
 
 ## Advanced Usage
 
@@ -237,15 +204,12 @@ from cmx import doc
 import pandas as pd
 import matplotlib.pyplot as plt
 
-# Data
-data = pd.DataFrame({
-    'x': range(10),
-    'y': [i**2 for i in range(10)]
-})
+doc.config(__file__)
 
-# Plot
+data = pd.DataFrame({"x": range(10), "y": [i**2 for i in range(10)]})
+
 plt.figure(figsize=(10, 6))
-plt.plot(data['x'], data['y'])
+plt.plot(data["x"], data["y"])
 
 with doc:
     doc("# Analysis Results")
@@ -254,76 +218,46 @@ with doc:
     doc.table(data)
 
     doc("## Visualization")
-    doc.savefig("figures/analysis.png", caption="Quadratic growth pattern")
+    doc.savefig("analysis.png", caption="Quadratic growth")
 
     doc("## Summary Statistics")
     doc.yaml(data.describe().to_dict())
-```
 
-### Custom Component Styling
-
-Components support custom attributes:
-
-```python
-with doc:
-    # Custom width and alignment
-    doc.image(img, src="wide.png", width="100%", style="border: 1px solid black")
-
-    # Custom table styling
-    doc.table(df, class_name="custom-table")
-```
-
-## Component Backends
-
-Different backends render components differently:
-
-- **Markdown**: Maximum compatibility, works on GitHub
-- **HTML**: Rich formatting, interactive elements
-- **LaTeX**: Academic papers, publication-ready
-
-Switch backends:
-
-```python
-from cmx.backends.html import HTML
-from cmx.backends.latex import LaTeX
-
-# Use HTML backend
-doc = HTML(filename="output.html")
-
-# Use LaTeX backend
-doc = LaTeX(filename="output.tex")
+doc.flush()
 ```
 
 ## Best Practices
 
-1. **Use meaningful filenames**: `figures/training_loss.png` not `fig1.png`
-2. **Add captions**: Help readers understand visualizations
-3. **Normalize images**: Use `normalize=True` for consistent display
-4. **Keep tables readable**: Don't show too many rows/columns
-5. **Organize outputs**: Use subdirectories (`figures/`, `videos/`, etc.)
+1. **Pass bare asset names** (`"loss.png"`) and let `figdir` organize them; use a slashed path only when an asset must live somewhere specific.
+2. **Add captions** to figures to help readers.
+3. **Normalize images** with `normalize=True` for consistent display.
+4. **Keep tables readable** — limit rows/columns; use `show_index=True` only when the index matters.
+5. **Stay on the default `github` table format** unless you need a specific layout — it keeps `tabulate` out of your install.
 
 ## Troubleshooting
 
 ### Images not displaying
 
-- Check that the `src` path is correct
-- Ensure the directory exists (CMX doesn't create directories)
-- For remote logging, verify logger configuration
+- Check that the `src` is what you expect: a bare name lands under `figdir`, a slashed name is used as-is, and links are written relative to the `.md`.
+- You do **not** need to pre-create directories — CMX's default `on_save` creates them automatically when it writes the asset.
 
 ### Tables not formatting correctly
 
-- Ensure data is a pandas DataFrame
-- Check for special characters that might break markdown
-- Use `show_index=False` to hide the index column
+- Tables need `cmx[tables]` (pandas). The default `github` format needs only pandas; alternate `format=` values need `tabulate`.
+- Ensure data is a DataFrame, a CSV string, or loadable via `file=`.
+- Use `show_index=False` (the default) to hide the index.
 
 ### Videos not playing
 
-- GIFs work everywhere, MP4 only in HTML backend
-- Check file size (large videos might not display)
-- Verify codec compatibility for MP4 files
+- GIFs render as images and work everywhere; `.mp4`/`.webm` render as HTML5 `<video>` and show only where HTML is rendered.
+- Check file size and codec compatibility for MP4.
+
+### Routing assets elsewhere (S3, a dashboard, ...)
+
+- There is no logger. Override the `on_save` lifecycle hook (bind on the instance, or subclass `CommonMark`) to write bytes wherever you want and return the link CMX renders. See the basics skill's "Storage & integration hooks" and the Hooks guide.
 
 ## Learn More
 
+- Full documentation: https://cmx-python.readthedocs.io
 - API Reference: https://cmx-python.readthedocs.io/en/latest/api/
-- Examples: Check `examples/` directory in the repository
 - Component source: `src/cmx/backends/components.py`


### PR DESCRIPTION
Update the Claude Code plugin skills (`.claude-plugin/cmx-basics.md`, `cmx-components.md`) to match the shipped 0.0.49 API. Verified against the source.

- `doc.config(__file__)` primary; `figdir`/`{fname}` asset model; bare-name vs slashed-path resolution.
- Correct `doc.hide` (runs, source hidden, vars persist) vs `doc.skip` (does not run).
- Dependency-free core + extras (`tables`/`images`/`figures`/`yaml`/`all`); `tabulate` is not a runtime dep (default github via `md_table`).
- Replace removed ML-Logger/`SimpleLogger` framing with **lifecycle hooks** (`on_mount`/`on_save`/`on_flush`/`on_close`/`on_error` + `on_block`/`on_hide`/`on_skip`); both override styles.
- Drop non-functional HTML/LaTeX backend switching (stubs).
- Add `end=`, the three text forms, `doc.print` coalescing, `doc.table(file=)` / `doc.yaml(file=)`, `with doc.row():`; fix "CMX doesn't create directories".

🤖 Generated with [Claude Code](https://claude.com/claude-code)