### PR TITLE
Document figure_row media tables (docs + tests + components skill)

### DIFF
--- a/.claude-plugin/cmx-components.md
+++ b/.claude-plugin/cmx-components.md
@@ -7,7 +7,7 @@ This skill provides detailed guidance on CMX's rich components for building docu
 - **Text**: prose via `@` / `|` / call forms
 - **Print**: `print`-style output, coalesced into code blocks
 - **Pre / YAML**: raw and YAML code blocks
-- **Table**: tabular data from DataFrames, CSV, or files
+- **Table**: tabular data from DataFrames, CSV, or files — or a figure grid via `table.figure_row()`
 - **Image**: array or file images, auto-saved through `on_save`
 - **Figure / Savefig**: images and matplotlib figures with titles/captions
 - **Video**: video and GIF embedding
@@ -100,6 +100,40 @@ doc.csv("Model,Accuracy\nResNet50,0.95\nVGG16,0.87")
 doc.table(file="data.csv")       # also .tsv / .json / .parquet / .xlsx / .yaml
 doc.table(file="metrics.parquet")
 ```
+
+### Figure grids — media tables with `figure_row`
+
+`doc.table()` with no data starts an empty table filled via
+`table.figure_row()`. Each figure row is one band of cells, rendered as up to
+three Markdown rows — **titles**, **cells**, **captions** — with unused bands
+dropped. Cell methods (one column each):
+
+```python
+with doc.table() as table:
+    for ep in ("0000", "0001", "0002"):
+        with table.figure_row() as row:
+            row.column(title="episode", text=f"`{ep}`")     # plain-text cell
+            row.figure(src=f"episodes/{ep}/frame.png",       # image cell
+                       title="first frame", caption="step 0")
+            row.video(src=f"episodes/{ep}/rollout.gif",      # media cell
+                      title="rollout")
+            # row.savefig("plot.png", ...) captures the current mpl figure
+```
+
+Rules that matter in practice:
+
+- **GIFs in cells, MP4s below the table.** A `.gif` src renders as a
+  single-line image link (table-safe). Any other extension renders as a
+  multi-line HTML5 `<video>` block that **breaks a Markdown table cell** —
+  embed it standalone with `doc.video(src="x.mp4")` after the table.
+- **Placeholder cells.** With only `src=` (no array/frames), the default
+  `on_save` does no I/O: the link renders without writing a file, so cells
+  can point at artifacts a pipeline has not produced yet — the report fills
+  in as files appear. Links resolve relative to the `.md` file.
+- **figdir rule applies**: bare names land under `figdir`; slashed paths are
+  used as-is.
+- src-only links need no extras; writing arrays through cells needs
+  `cmx[images]`.
 
 ## Image Component
 
@@ -250,6 +284,7 @@ doc.flush()
 ### Videos not playing
 
 - GIFs render as images and work everywhere; `.mp4`/`.webm` render as HTML5 `<video>` and show only where HTML is rendered.
+- Never put an `.mp4` in a `figure_row` cell — the multi-line `<video>` block breaks the Markdown table. Use a GIF preview in the cell and the MP4 in a standalone `doc.video` block.
 - Check file size and codec compatibility for MP4.
 
 ### Routing assets elsewhere (S3, a dashboard, ...)

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -127,8 +127,80 @@ doc @ """
 
 The text passes through unchanged, so this needs no extras.
 
+## Figure grids and media cells
+
+`doc.table()` with no data starts an empty table that you fill with
+`table.figure_row()`. Each figure row is one horizontal band of cells; the
+table renders every band as up to three Markdown rows — **titles**, **cells**,
+**captions** — and drops the rows a band never used.
+
+```python
+with doc.table() as table:
+    for ep in ("0000", "0001", "0002"):
+        with table.figure_row() as row:
+            row.column(title="episode", text=f"`{ep}`")
+            row.figure(src=f"episodes/{ep}/frame.png", title="first frame")
+            row.video(src=f"episodes/{ep}/rollout.gif", title="rollout")
+```
+
+The cell methods, one column each:
+
+- `row.column(title=None, text=None, footer=None)` — a plain-text cell; use it
+  to label media columns with ids, paths, or metrics.
+- `row.figure(image=None, src=None, title=None, caption=None)` — an image
+  cell. With an array the bytes are written through the document's `on_save`
+  hook; with only `src=` the link is rendered as-is.
+- `row.video(frames=None, src=None, title=None, caption=None)` — a video
+  cell; see the GIF/MP4 rule below.
+- `row.savefig(key, title=None, caption=None, ...)` — capture the current
+  matplotlib figure into a cell (see [Figures](figures.md)).
+
+Media cells need no extras when you only pass `src=` links; writing arrays
+needs `cmx[images]`.
+
+### GIFs go in cells, MP4s go below the table
+
+A `.gif` `src` renders as an image link (`![...](...)`), which works inside a
+table cell anywhere Markdown renders. Any other extension renders as a
+multi-line HTML5 `<video>` block — and Markdown table cells are single-line,
+so an `.mp4` cell breaks the table. Put GIF previews in the cells and embed
+the full video in a standalone block after the table:
+
+```python
+row.video(src="rollout.gif", title="preview")   # in the cell
+doc.video(src="rollout.mp4")                    # below the table
+```
+
+### Placeholder cells — link artifacts that do not exist yet
+
+When a cell gets only `src=` (no array, no frames), the default `on_save`
+hook does **no I/O**: the link is rendered without writing a file. Cells can
+therefore point at artifacts your pipeline has not produced yet, and the
+report becomes a live dashboard — the images and previews appear the moment
+the files are written, with no change to the document.
+
+```python
+t = doc.table()
+for ep in ("0000", "0001"):
+    row = t.figure_row()
+    row.column(title="episode", text=f"`{ep}`")
+    row.column(title="goal", text=f"`outputs/{ep}/goal.json`")
+    row.figure(src=f"../data/outputs/{ep}/images/rgb/00000.png", title="first ego frame")
+    row.video(src=f"../data/outputs/{ep}/images/rgb/ego.gif", title="rollout")
+```
+
+Links are written into the markdown verbatim and resolve relative to the
+`.md` file, so compute them accordingly (`../data/...` from a `docs/` folder).
+
+### Path resolution in figure rows
+
+Figure-row assets follow the same rule as `doc.image`: a **bare name**
+(`"loss.png"`) lands under the document's `figdir`; a name **with a slash**
+(`"episodes/0000/frame.png"`) is used as-is — explicit wins.
+
 ## Next steps
 
 - [Installation](installation.md) — install the `cmx[tables]` extra and other optional features.
 - [Images](images.md) — arrange figures in grids and rows.
+- [Figures](figures.md) — matplotlib figure grids with `row.savefig`.
 - [Printing](printing.md) — add computed output with `doc.print()`.

--- a/tests/test_table_figure_row.py
+++ b/tests/test_table_figure_row.py
@@ -1,4 +1,5 @@
-from cmx.backends.components import Article
+from cmx.backends.components import Article, Image, Video
+from cmx.backends.markdown import CommonMark
 
 
 def test_figure_row():
@@ -26,3 +27,79 @@ def test_figure_row():
 | ![some_file.png](some_file.png) | ![some_file.png](some_file.png) | ![some_file.png](some_file.png) | ![some_file.png](some_file.png) |
 | some text | some text | some text | some text |
 """[1:]
+
+
+def test_mixed_text_and_media_row():
+    """`row.column` text cells sit alongside figure/video cells; the band
+    renders as a titles row, a cells row, and a captions row."""
+    doc = Article()
+    table = doc.table()
+    row = table.figure_row()
+    row.column(title="episode", text="`0000`")
+    row.figure(src="frame.png", title="first frame", caption="step 0")
+    row.video(src="rollout.gif", title="rollout", caption="preview")
+
+    md = table._md
+    lines = md.strip().split("\n")
+    # titles band, separator, cells band, captions band
+    assert len(lines) == 4
+    assert lines[0] == "| **episode** | **first frame** | **rollout** |"
+    assert "`0000`" in lines[2]
+    assert "(frame.png)" in lines[2]
+    assert "(rollout.gif)" in lines[2]
+    # captions band: column footer omitted -> blank cell, then the two captions
+    assert lines[3].count("|") == 4
+    assert "step 0" in lines[3] and "preview" in lines[3]
+
+
+def test_gif_renders_in_cell_mp4_is_html_video():
+    """A `.gif` src becomes an Image (single-line, table-safe); any other
+    extension becomes an HTML5 Video block, which is multi-line and therefore
+    must not go inside a Markdown table cell."""
+    doc = Article()
+    row = doc.table().figure_row()
+    row.video(src="preview.gif")
+    row.video(src="full.mp4")
+
+    gif_cell, mp4_cell = row.children
+    assert isinstance(gif_cell, Image)
+    assert isinstance(mp4_cell, Video)
+    assert "\n" not in gif_cell._md.strip()
+    assert "\n" in mp4_cell._md.strip()  # <video> block: never put in a cell
+
+
+def test_empty_bands_are_dropped():
+    """A band with no titles and no captions renders as just the cells row
+    (plus the separator)."""
+    doc = Article()
+    table = doc.table()
+    row = table.figure_row()
+    row.figure(src="a.png")
+    row.figure(src="b.png")
+
+    lines = table._md.strip().split("\n")
+    assert len(lines) == 2  # cells row + separator, no title/caption bands
+    assert "(a.png)" in lines[0] and "(b.png)" in lines[0]
+
+
+def test_link_only_cells_write_nothing(tmp_path):
+    """src-only cells route through the default on_save with data=None, which
+    does no I/O — the link renders now, the artifact can appear later."""
+    doc = CommonMark()
+    doc.config(file=str(tmp_path / "report.md"))
+
+    table = doc.table()
+    row = table.figure_row()
+    row.column(title="episode", text="`0000`")
+    row.figure(src="pending/frame.png", title="first frame")
+    row.video(src="pending/rollout.gif", title="rollout")
+
+    md = table._md
+    assert "(pending/frame.png)" in md
+    assert "(pending/rollout.gif)" in md
+    # nothing was written for the placeholder links
+    assert not (tmp_path / "pending").exists()
+
+    doc.flush()
+    assert (tmp_path / "report.md").exists()
+    assert not (tmp_path / "pending").exists()


### PR DESCRIPTION
## Summary

`table.figure_row()` is the workhorse for media-heavy reports (figure grids, episode dashboards), but its usage details lived only in the source. This PR documents them where users look, pins them with tests, and teaches them to the Claude plugin skill:

- **docs/tables.md** — new *Figure grids and media cells* section:
  - `doc.table()` + `figure_row()` bands render as up to three Markdown rows (titles / cells / captions), with unused bands dropped
  - the four cell methods: `row.column` (text cells for ids/paths/metrics), `row.figure`, `row.video`, `row.savefig`
  - **GIFs in cells, MP4s below the table** — `.gif` renders as a single-line image link (table-safe); other extensions render as a multi-line HTML5 `<video>` block that breaks a Markdown table cell
  - **placeholder cells** — src-only cells route through `on_save` with `data=None` (no I/O), so a report can link artifacts a pipeline hasn't produced yet and fill in as files appear
  - figdir path resolution in figure rows (bare name → figdir, slashed path as-is)
- **tests/test_table_figure_row.py** — four new tests pinning each of the above: mixed text+media rows, gif→`Image` vs mp4→`Video` cell components (and that `Video._md` is multi-line), empty-band dropping, and link-only cells writing nothing through the real default `on_save`
- **.claude-plugin/cmx-components.md** — figure-grid section mirroring the doc, plus an mp4-in-cell troubleshooting note

These details were battle-tested building a pipeline test suite that emits CMX reports with episode media tables (images/videos under a table, wired to not-yet-generated artifacts).

## Test plan

- `uv run --all-extras pytest` → 118 passed (5 in `test_table_figure_row.py`)