### PR TITLE
fix(release): stop shadowing Read the Docs 'latest' with a git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,16 +47,16 @@ update-plugin:
 prepare: update-plugin
 	# Remove existing tags
 	git tag -d $(VERSION) || true
-	git tag -d latest || true
 	git push origin :refs/tags/$(VERSION) || true
-	git push origin :refs/tags/latest || true
 
+# Do NOT create a git tag named `latest`: Read the Docs treats a branch or tag
+# named `latest` as the "latest" docs version, shadowing its default behavior
+# of building `latest` from the default branch (main) on every push.
 release: prepare
 	git add -A
 	git commit -m "Release version $(VERSION)" || true
 	git push
 	git tag v$(VERSION) -m "$(msg)"
-	git tag latest -m "Latest release"
 	git push origin --tags
 
 publish-no-test: convert-rst wheel

--- a/docs/development.md
+++ b/docs/development.md
@@ -143,6 +143,8 @@ The HTML lands in `docs/_build/html/`.
    make release msg="Release version 0.0.48"
    ```
 
+Documentation deploys automatically: Read the Docs rebuilds [cmx.readthedocs.io](https://cmx.readthedocs.io) from `main` on every push, so the docs update as soon as the release lands. Do not create a branch or tag named `latest` — Read the Docs would build the `latest` docs from it instead of from `main`.
+
 :::{warning}
 `make publish` uploads to the live PyPI index. Run `make test` and verify the wheel locally with `make dev` before publishing.
 :::


### PR DESCRIPTION
## Problem

Docs at cmx.readthedocs.io were stale: pushes to `main` returned `build_triggered: false` from the RTD webhook, and the last build was from June 26.

Root cause: `make release` creates a git tag named `latest`. Read the Docs treats a branch/tag named `latest` as *the* latest docs version (`type: tag`, pinned to a commit), which **shadows** its default behavior of building `latest` from the default branch on every push. So docs only updated when the tag was force-moved during a release — never on merge.

## Fix

- `make prepare` / `make release` no longer delete/create the `latest` tag (with a comment explaining why it must not come back)
- `docs/development.md` documents that RTD rebuilds from `main` on every push

## Follow-up (one-time, manual)

Delete the existing remote tag so RTD falls back to tracking `main`:

```bash
git push origin :refs/tags/latest && git tag -d latest
```